### PR TITLE
docs: use `@internal` instead of `@inner`

### DIFF
--- a/async/chain.ts
+++ b/async/chain.ts
@@ -35,7 +35,7 @@ export async function* chain<
 }
 
 /**
- * @inner
+ * @internal
  */
 export type Chain<T> = T extends readonly [] ? never
   : T extends readonly [Iterable<infer U>] ? U

--- a/async/zip.ts
+++ b/async/zip.ts
@@ -33,7 +33,7 @@ export async function* zip<
 }
 
 /**
- * @inner
+ * @internal
  */
 export type Zip<T extends (Iterable<unknown> | AsyncIterable<unknown>)[]> = {
   [P in keyof T]: T[P] extends Iterable<infer U> ? U

--- a/chain.ts
+++ b/chain.ts
@@ -29,7 +29,7 @@ export function* chain<T extends Iterable<unknown>[]>(
 }
 
 /**
- * @inner
+ * @internal
  */
 export type Chain<T> = T extends readonly [] ? never
   : T extends readonly [Iterable<infer U>] ? U

--- a/zip.ts
+++ b/zip.ts
@@ -26,7 +26,7 @@ export function* zip<U extends Iterable<unknown>[]>(
 }
 
 /**
- * @inner
+ * @internal
  */
 export type Zip<T extends Iterable<unknown>[]> = {
   [P in keyof T]: T[P] extends Iterable<infer U> ? U : never;


### PR DESCRIPTION
it seems JSR does not treat `@inner` specially but `@internal`