### PR TITLE
fix(filter): Support narrowing by type predicate

### DIFF
--- a/async/filter.ts
+++ b/async/filter.ts
@@ -1,11 +1,11 @@
-export function filter<T>(
-  iterable: Iterable<T> | AsyncIterable<T>,
-  fn: (value: T, index: number) => boolean | Promise<boolean>,
-): AsyncIterable<T>;
 export function filter<T, U extends T>(
   iterable: Iterable<T> | AsyncIterable<T>,
   fn: (value: T, index: number) => value is U,
 ): AsyncIterable<U>;
+export function filter<T>(
+  iterable: Iterable<T> | AsyncIterable<T>,
+  fn: (value: T, index: number) => boolean | Promise<boolean>,
+): AsyncIterable<T>;
 /**
  * Filters an iterable based on a function.
  *

--- a/async/filter.ts
+++ b/async/filter.ts
@@ -1,3 +1,11 @@
+export function filter<T>(
+  iterable: Iterable<T> | AsyncIterable<T>,
+  fn: (value: T, index: number) => boolean | Promise<boolean>,
+): AsyncIterable<T>;
+export function filter<T, U extends T>(
+  iterable: Iterable<T> | AsyncIterable<T>,
+  fn: (value: T, index: number) => value is U,
+): AsyncIterable<U>;
 /**
  * Filters an iterable based on a function.
  *

--- a/async/filter_test.ts
+++ b/async/filter_test.ts
@@ -69,3 +69,11 @@ await test("filter with iterable with promise", async () => {
   assertEquals(indices, [0, 1, 2, 3, 4]);
   assertType<IsExact<typeof result, AsyncIterable<number>>>(true);
 });
+
+await test("filter with type predicate", async () => {
+  const predicate = (v: number | string): v is number => typeof v === "number";
+  const result = filter([1, "a", 2, "b", 3], predicate);
+  const expected = [1, 2, 3];
+  assertEquals(await Array.fromAsync(result), expected);
+  assertType<IsExact<typeof result, AsyncIterable<number>>>(true);
+});

--- a/filter.ts
+++ b/filter.ts
@@ -1,11 +1,11 @@
-export function filter<T>(
-  iterable: Iterable<T>,
-  fn: (value: T, index: number) => boolean,
-): Iterable<T>;
 export function filter<T, U extends T>(
   iterable: Iterable<T>,
   fn: (value: T, index: number) => value is U,
 ): Iterable<U>;
+export function filter<T>(
+  iterable: Iterable<T>,
+  fn: (value: T, index: number) => boolean,
+): Iterable<T>;
 /**
  * Filters an iterable based on a function.
  *

--- a/filter.ts
+++ b/filter.ts
@@ -1,3 +1,11 @@
+export function filter<T>(
+  iterable: Iterable<T>,
+  fn: (value: T, index: number) => boolean,
+): Iterable<T>;
+export function filter<T, U extends T>(
+  iterable: Iterable<T>,
+  fn: (value: T, index: number) => value is U,
+): Iterable<U>;
 /**
  * Filters an iterable based on a function.
  *

--- a/filter_test.ts
+++ b/filter_test.ts
@@ -17,3 +17,11 @@ test("filter", () => {
   assertEquals(indices, [0, 1, 2, 3, 4]);
   assertType<IsExact<typeof result, Iterable<number>>>(true);
 });
+
+test("filter with type predicate", () => {
+  const predicate = (v: number | string): v is number => typeof v === "number";
+  const result = filter([1, "a", 2, "b", 3], predicate);
+  const expected = [1, 2, 3];
+  assertEquals(Array.from(result), expected);
+  assertType<IsExact<typeof result, Iterable<number>>>(true);
+});

--- a/pipe/async/filter.ts
+++ b/pipe/async/filter.ts
@@ -1,5 +1,11 @@
 import { filter as base } from "../../async/filter.ts";
 
+export function filter<T>(
+  fn: (value: T, index: number) => boolean | Promise<boolean>,
+): (iterable: Iterable<T> | AsyncIterable<T>) => AsyncIterable<T>;
+export function filter<T, U extends T>(
+  fn: (value: T, index: number) => value is U,
+): (iterable: Iterable<T> | AsyncIterable<T>) => AsyncIterable<U>;
 /**
  * Returns an operator that filters an iterable based on a function.
  *

--- a/pipe/async/filter.ts
+++ b/pipe/async/filter.ts
@@ -1,11 +1,11 @@
 import { filter as base } from "../../async/filter.ts";
 
-export function filter<T>(
-  fn: (value: T, index: number) => boolean | Promise<boolean>,
-): (iterable: Iterable<T> | AsyncIterable<T>) => AsyncIterable<T>;
 export function filter<T, U extends T>(
   fn: (value: T, index: number) => value is U,
 ): (iterable: Iterable<T> | AsyncIterable<T>) => AsyncIterable<U>;
+export function filter<T>(
+  fn: (value: T, index: number) => boolean | Promise<boolean>,
+): (iterable: Iterable<T> | AsyncIterable<T>) => AsyncIterable<T>;
 /**
  * Returns an operator that filters an iterable based on a function.
  *

--- a/pipe/async/filter_test.ts
+++ b/pipe/async/filter_test.ts
@@ -13,3 +13,14 @@ test("filter usage", async () => {
   assertEquals(await Array.fromAsync(result), expected);
   assertType<IsExact<typeof result, AsyncIterable<number>>>(true);
 });
+
+test("filter usage with type predicate", async () => {
+  const predicate = (v: number | string): v is number => typeof v === "number";
+  const result = pipe(
+    [1, "a", 2, "b", 3],
+    filter(predicate),
+  );
+  const expected = [1, 2, 3];
+  assertEquals(await Array.fromAsync(result), expected);
+  assertType<IsExact<typeof result, AsyncIterable<number>>>(true);
+});

--- a/pipe/filter.ts
+++ b/pipe/filter.ts
@@ -1,11 +1,11 @@
 import { filter as base } from "../filter.ts";
 
-export function filter<T>(
-  fn: (value: T, index: number) => boolean,
-): (iterable: Iterable<T>) => Iterable<T>;
 export function filter<T, U extends T>(
   fn: (value: T, index: number) => value is U,
 ): (iterable: Iterable<T>) => Iterable<U>;
+export function filter<T>(
+  fn: (value: T, index: number) => boolean,
+): (iterable: Iterable<T>) => Iterable<T>;
 /**
  * Returns an operator that filters an iterable based on a function.
  *

--- a/pipe/filter.ts
+++ b/pipe/filter.ts
@@ -1,5 +1,11 @@
 import { filter as base } from "../filter.ts";
 
+export function filter<T>(
+  fn: (value: T, index: number) => boolean,
+): (iterable: Iterable<T>) => Iterable<T>;
+export function filter<T, U extends T>(
+  fn: (value: T, index: number) => value is U,
+): (iterable: Iterable<T>) => Iterable<U>;
 /**
  * Returns an operator that filters an iterable based on a function.
  *

--- a/pipe/filter_test.ts
+++ b/pipe/filter_test.ts
@@ -13,3 +13,14 @@ test("filter usage", () => {
   assertEquals(Array.from(result), expected);
   assertType<IsExact<typeof result, Iterable<number>>>(true);
 });
+
+test("filter usage with type predicate", () => {
+  const predicate = (v: number | string): v is number => typeof v === "number";
+  const result = pipe(
+    [1, "a", 2, "b", 3],
+    filter(predicate),
+  );
+  const expected = [1, 2, 3];
+  assertEquals(Array.from(result), expected);
+  assertType<IsExact<typeof result, Iterable<number>>>(true);
+});


### PR DESCRIPTION
[Built-in `Array.prototype.filter`](https://github.com/denoland/deno/blob/v1.45.5/cli/tsc/dts/lib.es5.d.ts#L1469) has an overload that allows us to narrow the type by type predicate.
This pull request adds a support for this also to iterutil.
